### PR TITLE
Fix login modal theme styling

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -559,6 +559,54 @@ i.fa {
 
 .modal-title {
     display: inline-block;
+    color: var(--color-text);
+}
+
+.modal-content {
+    background-color: var(--color-content-bg);
+    color: var(--color-text);
+    border-color: var(--color-border);
+    box-shadow: var(--shadow-card);
+}
+
+.modal-header,
+.modal-footer {
+    border-color: var(--color-border);
+}
+
+.modal .close {
+    color: var(--color-text);
+    text-shadow: none;
+    opacity: 0.7;
+}
+
+.modal .close:hover,
+.modal .close:focus {
+    color: var(--color-text);
+    opacity: 1;
+}
+
+.modal .form-control {
+    background-color: var(--color-surface);
+    color: var(--color-text);
+    border-color: var(--color-border);
+}
+
+.modal .form-control::placeholder {
+    color: var(--color-text-muted);
+    opacity: 1;
+}
+
+.modal a,
+.modal a:active,
+.modal a:visited {
+    color: var(--color-accent);
+}
+
+.modal a:hover,
+.modal a:focus {
+    color: var(--color-accent-hover);
+    text-decoration: none;
 }
 
 /* Edit and Delete icons on the news page */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Theme Bootstrap modal surfaces, borders, text, close buttons, form inputs, placeholders, and links with existing light/dark CSS tokens
- Ensure modal titles such as the login header remain visible in dark mode

## Testing
- `npm test -- --runInBand`
- `npm run build` (passes with existing webpack "mode" warning)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac3697b2-82bf-4f67-8187-4815a3a7651f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac3697b2-82bf-4f67-8187-4815a3a7651f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

