### PR TITLE
Fix theme toggle after HTMX login redirect

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -363,9 +363,31 @@ li.dropdown:hover > .dropdown-menu a:hover,
     outline: none;
 }
 
-.theme-toggle i {
+.theme-toggle-icon {
     font-size: 16px;
     margin: 0;
+}
+
+.theme-toggle-icon--dark {
+    display: none;
+}
+
+[data-theme="dark"] .theme-toggle-icon--light {
+    display: none;
+}
+
+[data-theme="dark"] .theme-toggle-icon--dark {
+    display: inline-block;
+}
+
+@media (prefers-color-scheme: dark) {
+    html:not([data-theme]) .theme-toggle-icon--light {
+        display: none;
+    }
+
+    html:not([data-theme]) .theme-toggle-icon--dark {
+        display: inline-block;
+    }
 }
 
 #lastedit {

--- a/public/js/theme.js
+++ b/public/js/theme.js
@@ -33,19 +33,12 @@
     }
   }
 
-  function updateToggleIcon(theme) {
-    const toggles = document.querySelectorAll(".theme-toggle");
-    toggles.forEach(function(toggle) {
-      const icon = toggle.querySelector("i");
-      if (!icon) {
-        return;
-      }
+  function updateToggleLabels(theme) {
+    document.querySelectorAll(".theme-toggle").forEach(function(toggle) {
       if (theme === "dark") {
-        icon.className = "fa fa-sun-o";
         toggle.setAttribute("title", "Switch to light mode");
         toggle.setAttribute("aria-label", "Switch to light mode");
       } else {
-        icon.className = "fa fa-moon-o";
         toggle.setAttribute("title", "Switch to dark mode");
         toggle.setAttribute("aria-label", "Switch to dark mode");
       }
@@ -55,7 +48,7 @@
   function applyTheme(theme, persist) {
     document.documentElement.setAttribute("data-theme", theme);
     applyHljsTheme(theme);
-    updateToggleIcon(theme);
+    updateToggleLabels(theme);
 
     if (persist) {
       document.cookie = THEME_COOKIE + "=" + theme + "; max-age=31536000; path=/; SameSite=Lax";

--- a/public/js/theme.js
+++ b/public/js/theme.js
@@ -1,90 +1,106 @@
-const THEME_COOKIE = "theme";
+(function() {
+  const THEME_COOKIE = "theme";
 
-function getCookie(name) {
-  const match = document.cookie.match(new RegExp("(?:^|; )" + name + "=([^;]*)"));
-  return match ? decodeURIComponent(match[1]) : null;
-}
-
-function getSystemTheme() {
-  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-}
-
-function getStoredTheme() {
-  const cookieTheme = getCookie(THEME_COOKIE);
-  if (cookieTheme === "light" || cookieTheme === "dark") {
-    return cookieTheme;
+  function getCookie(name) {
+    const match = document.cookie.match(new RegExp("(?:^|; )" + name + "=([^;]*)"));
+    return match ? decodeURIComponent(match[1]) : null;
   }
-  return getSystemTheme();
-}
 
-function applyHljsTheme(theme) {
-  const lightLink = document.getElementById("hljs-light");
-  const darkLink = document.getElementById("hljs-dark");
-  if (!lightLink || !darkLink) {
-    return;
+  function getSystemTheme() {
+    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
   }
-  if (theme === "dark") {
-    lightLink.media = "not all";
-    darkLink.media = "all";
-  } else {
-    lightLink.media = "all";
-    darkLink.media = "not all";
+
+  function getStoredTheme() {
+    const cookieTheme = getCookie(THEME_COOKIE);
+    if (cookieTheme === "light" || cookieTheme === "dark") {
+      return cookieTheme;
+    }
+    return getSystemTheme();
   }
-}
 
-function applyTheme(theme, persist) {
-  document.documentElement.setAttribute("data-theme", theme);
-  applyHljsTheme(theme);
-  updateToggleIcon(theme);
-
-  if (persist) {
-    document.cookie = THEME_COOKIE + "=" + theme + "; max-age=31536000; path=/; SameSite=Lax";
-  }
-}
-
-function updateToggleIcon(theme) {
-  const toggles = document.querySelectorAll(".theme-toggle");
-  toggles.forEach(function(toggle) {
-    const icon = toggle.querySelector("i");
-    if (!icon) {
+  function applyHljsTheme(theme) {
+    const lightLink = document.getElementById("hljs-light");
+    const darkLink = document.getElementById("hljs-dark");
+    if (!lightLink || !darkLink) {
       return;
     }
     if (theme === "dark") {
-      icon.className = "fa fa-sun-o";
-      toggle.setAttribute("title", "Switch to light mode");
-      toggle.setAttribute("aria-label", "Switch to light mode");
+      lightLink.media = "not all";
+      darkLink.media = "all";
     } else {
-      icon.className = "fa fa-moon-o";
-      toggle.setAttribute("title", "Switch to dark mode");
-      toggle.setAttribute("aria-label", "Switch to dark mode");
+      lightLink.media = "all";
+      darkLink.media = "not all";
     }
-  });
-}
+  }
 
-function toggleTheme() {
-  const current = document.documentElement.getAttribute("data-theme") || getStoredTheme();
-  const next = current === "dark" ? "light" : "dark";
-  applyTheme(next, true);
-}
+  function updateToggleIcon(theme) {
+    const toggles = document.querySelectorAll(".theme-toggle");
+    toggles.forEach(function(toggle) {
+      const icon = toggle.querySelector("i");
+      if (!icon) {
+        return;
+      }
+      if (theme === "dark") {
+        icon.className = "fa fa-sun-o";
+        toggle.setAttribute("title", "Switch to light mode");
+        toggle.setAttribute("aria-label", "Switch to light mode");
+      } else {
+        icon.className = "fa fa-moon-o";
+        toggle.setAttribute("title", "Switch to dark mode");
+        toggle.setAttribute("aria-label", "Switch to dark mode");
+      }
+    });
+  }
 
-window.getStoredTheme = getStoredTheme;
-window.applyTheme = applyTheme;
-window.toggleTheme = toggleTheme;
+  function applyTheme(theme, persist) {
+    document.documentElement.setAttribute("data-theme", theme);
+    applyHljsTheme(theme);
+    updateToggleIcon(theme);
 
-document.addEventListener("DOMContentLoaded", function() {
-  const theme = getStoredTheme();
-  applyTheme(theme, false);
+    if (persist) {
+      document.cookie = THEME_COOKIE + "=" + theme + "; max-age=31536000; path=/; SameSite=Lax";
+    }
+  }
 
-  document.querySelectorAll(".theme-toggle").forEach(function(toggle) {
-    toggle.addEventListener("click", function(event) {
+  function toggleTheme() {
+    const current = document.documentElement.getAttribute("data-theme") || getStoredTheme();
+    const next = current === "dark" ? "light" : "dark";
+    applyTheme(next, true);
+  }
+
+  function syncTheme() {
+    const theme = getStoredTheme();
+    applyTheme(theme, false);
+  }
+
+  window.getStoredTheme = getStoredTheme;
+  window.applyTheme = applyTheme;
+  window.toggleTheme = toggleTheme;
+
+  if (!document.documentElement.dataset.themeToggleBound) {
+    document.documentElement.dataset.themeToggleBound = "true";
+
+    document.addEventListener("click", function(event) {
+      const toggle = event.target.closest(".theme-toggle");
+      if (!toggle) {
+        return;
+      }
       event.preventDefault();
       toggleTheme();
     });
-  });
 
-  window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", function() {
-    if (!getCookie(THEME_COOKIE)) {
-      applyTheme(getSystemTheme(), false);
-    }
-  });
-});
+    window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", function() {
+      if (!getCookie(THEME_COOKIE)) {
+        applyTheme(getSystemTheme(), false);
+      }
+    });
+
+    document.addEventListener("htmx:afterSettle", syncTheme);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", syncTheme);
+  } else {
+    syncTheme();
+  }
+})();

--- a/views/partials/nav-no-login.handlebars
+++ b/views/partials/nav-no-login.handlebars
@@ -48,7 +48,7 @@
             <ul class="nav navbar-nav navbar-right">
                 <li>
                     <button type="button" class="theme-toggle" aria-label="Toggle color theme" title="Toggle color theme">
-                        <i class="fa fa-sun-o" aria-hidden="true"></i>
+                        <i class="fa fa-moon-o" aria-hidden="true"></i>
                     </button>
                 </li>
             </ul>

--- a/views/partials/nav-no-login.handlebars
+++ b/views/partials/nav-no-login.handlebars
@@ -47,8 +47,9 @@
             </ul>
             <ul class="nav navbar-nav navbar-right">
                 <li>
-                    <button type="button" class="theme-toggle" aria-label="Toggle color theme" title="Toggle color theme">
-                        <i class="fa fa-moon-o" aria-hidden="true"></i>
+                    <button type="button" class="theme-toggle" aria-label="Switch to dark mode" title="Switch to dark mode">
+                        <i class="fa fa-moon-o theme-toggle-icon theme-toggle-icon--light" aria-hidden="true"></i>
+                        <i class="fa fa-sun-o theme-toggle-icon theme-toggle-icon--dark" aria-hidden="true"></i>
                     </button>
                 </li>
             </ul>

--- a/views/partials/nav.handlebars
+++ b/views/partials/nav.handlebars
@@ -47,8 +47,9 @@
             </ul>
             <ul class="nav navbar-nav navbar-right">
                 <li>
-                    <button type="button" class="theme-toggle" aria-label="Toggle color theme" title="Toggle color theme">
-                        <i class="fa fa-moon-o" aria-hidden="true"></i>
+                    <button type="button" class="theme-toggle" aria-label="Switch to dark mode" title="Switch to dark mode">
+                        <i class="fa fa-moon-o theme-toggle-icon theme-toggle-icon--light" aria-hidden="true"></i>
+                        <i class="fa fa-sun-o theme-toggle-icon theme-toggle-icon--dark" aria-hidden="true"></i>
                     </button>
                 </li>
                 {{#if authenticated }} {{!-- This is coming from res.locals --}}

--- a/views/partials/nav.handlebars
+++ b/views/partials/nav.handlebars
@@ -48,7 +48,7 @@
             <ul class="nav navbar-nav navbar-right">
                 <li>
                     <button type="button" class="theme-toggle" aria-label="Toggle color theme" title="Toggle color theme">
-                        <i class="fa fa-sun-o" aria-hidden="true"></i>
+                        <i class="fa fa-moon-o" aria-hidden="true"></i>
                     </button>
                 </li>
                 {{#if authenticated }} {{!-- This is coming from res.locals --}}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After logging in via the modal, HTMX handles the redirect with `HX-Location`, which swaps the page body without a full reload. That re-executes `theme.js`, causing:

- `Uncaught SyntaxError: Identifier 'THEME_COOKIE' has already been declared`
- Theme toggle click handlers not attached to the new nav button
- Wrong toggle icon after login (nav swapped in with a static icon unrelated to the active theme)

## Solution

- Wrap `theme.js` in an IIFE so it can be safely re-executed during HTMX body swaps
- Use document-level click delegation for `.theme-toggle` (bound once via a guard flag)
- Re-sync theme and toggle labels on `htmx:afterSettle` when HTMX swaps in new content
- Render both moon and sun icons in the nav and show the correct one with CSS driven by `html[data-theme]`
  - `data-theme` is set synchronously in the header from the theme cookie or system preference before the body renders
  - After login, only the body is swapped, so the existing `data-theme` on `<html>` keeps the icon correct immediately

## Testing

- `npm test` passes
- `npm run build` succeeds
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-006efd29-671d-4972-b65b-ee7d4abf8d72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-006efd29-671d-4972-b65b-ee7d4abf8d72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

