### PR TITLE
Enable Trusted Types for HTMX swaps

### DIFF
--- a/config/urls.js
+++ b/config/urls.js
@@ -25,8 +25,7 @@ const fontSrc = [
 ];
 const frameSrc = [`https://www.google.com/recaptcha/`];
 const reportUri = [];
-const requireTrustedTypesFor = [];
-//const requireTrustedTypesFor = ["'script'"];
+const requireTrustedTypesFor = ["'script'"];
 
 export default {
   defaultSrc,

--- a/public/js/trustedtype.js
+++ b/public/js/trustedtype.js
@@ -1,15 +1,20 @@
-// Use the browser's built-in trustedTypes API
-if (typeof trustedTypes !== 'undefined') {
-  // Create a Trusted Types policy
-  const policy = trustedTypes.createPolicy('default', {
+(function () {
+  const passthroughPolicy = {
     createHTML: (input) => input,
     createScript: (input) => input,
-    createScriptURL: (input) => input
-  });
+    createScriptURL: (input) => input,
+  };
 
-  // Make the policy globally accessible
-  window.trustedTypesPolicy = policy;
-} else {
-  // Fallback if trustedTypes is not available
-  console.warn('Trusted Types not supported in this browser');
-}
+  if (window.trustedTypesPolicy) {
+    return;
+  }
+
+  if (!window.trustedTypes || !window.trustedTypes.createPolicy) {
+    window.trustedTypesPolicy = passthroughPolicy;
+    return;
+  }
+
+  // The default policy lets existing server-rendered HTMX swaps pass through
+  // Trusted Types sinks while CSP enforcement is enabled.
+  window.trustedTypesPolicy = window.trustedTypes.createPolicy("default", passthroughPolicy);
+})();

--- a/public/js/update-project.js
+++ b/public/js/update-project.js
@@ -1,15 +1,12 @@
-const defaultPolicy = trustedTypes.createPolicy('default', {
-  createHTML: (html) => html,
-});
-
 document.body.addEventListener("htmx:afterOnLoad", function(evt) {
   var trigger = evt.detail.xhr.getResponseHeader("HX-Trigger");
   if (trigger) {
     var data = JSON.parse(trigger);
     if (data.updateImage) {
+      var trustedTypesPolicy = window.trustedTypesPolicy || { createHTML: (html) => html };
       var parser = new DOMParser();
-      var doc = parser.parseFromString(data.updateImage, 'text/html');
-      var sanitizedHTML = defaultPolicy.createHTML(doc.body.innerHTML);
+      var doc = parser.parseFromString(trustedTypesPolicy.createHTML(data.updateImage), 'text/html');
+      var sanitizedHTML = trustedTypesPolicy.createHTML(doc.body.innerHTML);
       document.querySelector("#image-container").innerHTML = sanitizedHTML;
     }
   }

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -170,12 +170,9 @@ ROUTER.post(
       );
 
       let projectDescription = MARKDOWN.render(req.body.project_description);
-
-      // routes/projects.js
-      let projectSanitized = trustedTypes.createPolicy('default', {
-        createHTML: (html) => html
-      }).createHTML(sanitize(projectDescription, { allowedTags: safeTags }));
-
+      let projectSanitized = sanitize(projectDescription, {
+        allowedTags: safeTags,
+      });
 
       /*
         Default the project image to blank and if it exists, we can then set the image to the image from the

--- a/views/layouts/admin.handlebars
+++ b/views/layouts/admin.handlebars
@@ -29,7 +29,7 @@
         crossorigin="anonymous" nonce="{{nonce}}">
     </script>
     <script type="text/javascript" nonce="{{nonce}}" src="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"></script>
-    <script src="https://www.google.com/recaptcha/api.js?render=6LeCKqYUAAAAAAh4n_WgK7e-fKbqOgrukjjBmqBG" nonce="{{nonce}}" async defer></script>
+    <script src="https://www.google.com/recaptcha/api.js?trustedtypes=true&render=6LeCKqYUAAAAAAh4n_WgK7e-fKbqOgrukjjBmqBG" nonce="{{nonce}}" async defer></script>
     <!--<script type="text/javascript" src="/js/tabopen.js" nonce="{{nonce}}"></script>-->
 </body>
 </html>

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -31,10 +31,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.14.1/jquery-ui.min.js" nonce="{{nonce}}"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.0/highlight.min.js" nonce="{{nonce}}"></script>
     <script nonce="{{nonce}}">hljs.highlightAll();</script>
-    <!--<script rel="text/javascript" src="{{ versionedFile 'trustedtype.js' 'dist' 'js'}}" nonce="{{nonce}}"></script>-->
-    <script type="module" src="{{ versionedFile 'trustedtype.js' 'dist' 'js'}}" nonce="{{nonce}}"></script>
     {{!-- <script rel="text/javascript" src="{{ versionedFile 'welcome.js' 'dist' 'js'}}" nonce="{{nonce}}"></script> --}}
     {{!-- <script type="text/javascript" nonce="{{nonce}}" src="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"></script> --}}
-    {{!-- <script src="https://www.google.com/recaptcha/api.js?render=6LeCKqYUAAAAAAh4n_WgK7e-fKbqOgrukjjBmqBG" nonce="{{nonce}}" async defer></script> --}}
+    {{!-- <script src="https://www.google.com/recaptcha/api.js?trustedtypes=true&render=6LeCKqYUAAAAAAh4n_WgK7e-fKbqOgrukjjBmqBG" nonce="{{nonce}}" async defer></script> --}}
 </body>
 </html>

--- a/views/layouts/news.handlebars
+++ b/views/layouts/news.handlebars
@@ -27,7 +27,7 @@
         crossorigin="anonymous" nonce="{{nonce}}">
     </script>
     <script type="text/javascript" nonce="{{nonce}}" src="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"></script>
-    <script src="https://www.google.com/recaptcha/api.js?render=6LeCKqYUAAAAAAh4n_WgK7e-fKbqOgrukjjBmqBG" nonce="{{nonce}}" async defer></script>
+    <script src="https://www.google.com/recaptcha/api.js?trustedtypes=true&render=6LeCKqYUAAAAAAh4n_WgK7e-fKbqOgrukjjBmqBG" nonce="{{nonce}}" async defer></script>
     <script nonce="{{nonce}}" src="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js"></script>
     <script nonce="{{nonce}}">
         var simplemde = new SimpleMDE({ element: document.getElementById("editor"), toolbar: ["preview"], placeholder: "News Description Here - Write in Markdown", });

--- a/views/layouts/newsIndex.handlebars
+++ b/views/layouts/newsIndex.handlebars
@@ -28,7 +28,7 @@
         crossorigin="anonymous" nonce="{{nonce}}">
     </script>
     <!--<script type="text/javascript" nonce="{{nonce}}" src="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"></script>-->
-    <script src="https://www.google.com/recaptcha/api.js?render=6LeCKqYUAAAAAAh4n_WgK7e-fKbqOgrukjjBmqBG" nonce="{{nonce}}" async defer></script>
+    <script src="https://www.google.com/recaptcha/api.js?trustedtypes=true&render=6LeCKqYUAAAAAAh4n_WgK7e-fKbqOgrukjjBmqBG" nonce="{{nonce}}" async defer></script>
     <!--<script type="text/javascript" src="/js/tabopen.js" nonce="{{nonce}}"></script>-->
 </body>
 </html>

--- a/views/layouts/profile.handlebars
+++ b/views/layouts/profile.handlebars
@@ -25,7 +25,7 @@
         crossorigin="anonymous" nonce="{{nonce}}">
     </script>
     <script type="text/javascript" nonce="{{nonce}}" src="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"></script>
-    <script src="https://www.google.com/recaptcha/api.js?render=6LeCKqYUAAAAAAh4n_WgK7e-fKbqOgrukjjBmqBG" nonce="{{nonce}}" async defer></script>
+    <script src="https://www.google.com/recaptcha/api.js?trustedtypes=true&render=6LeCKqYUAAAAAAh4n_WgK7e-fKbqOgrukjjBmqBG" nonce="{{nonce}}" async defer></script>
     <!--<script type="text/javascript" src="/js/tabopen.js" nonce="{{nonce}}"></script>-->
 </body>
 </html>

--- a/views/layouts/reset.handlebars
+++ b/views/layouts/reset.handlebars
@@ -22,7 +22,7 @@
         crossorigin="anonymous" nonce="{{nonce}}">
     </script>
     <script type="text/javascript" nonce="{{nonce}}" src="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"></script>
-    <script src="https://www.google.com/recaptcha/api.js?render=6LeCKqYUAAAAAAh4n_WgK7e-fKbqOgrukjjBmqBG" nonce="{{nonce}}" async defer></script>
+    <script src="https://www.google.com/recaptcha/api.js?trustedtypes=true&render=6LeCKqYUAAAAAAh4n_WgK7e-fKbqOgrukjjBmqBG" nonce="{{nonce}}" async defer></script>
     <!--<script type="text/javascript" src="/js/tabopen.js" nonce="{{nonce}}"></script>-->
 </body>
 </html>

--- a/views/partials/header.handlebars
+++ b/views/partials/header.handlebars
@@ -21,6 +21,7 @@
     <link rel="stylesheet" href="{{ versionedFile 'github.css' 'dist' 'css'}}">
     <link id="hljs-light" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css" media="(prefers-color-scheme: light)">
     <link id="hljs-dark" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css" media="(prefers-color-scheme: dark)">
+    <script rel="text/javascript" src="{{ versionedFile 'trustedtype.js' 'dist' 'js'}}" nonce="{{nonce}}"></script>
     <script nonce="{{nonce}}">
     (function() {
         var theme = document.documentElement.getAttribute('data-theme');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Re-enable `require-trusted-types-for 'script'` in the CSP config.
- Load a shared default Trusted Types policy early from the common header so HTMX swaps and dynamic DOM sinks have a policy before initialization.
- Reuse the shared policy in the project image update script and remove server-side browser Trusted Types usage.
- Add `trustedtypes=true` to remaining reCAPTCHA script URLs.

## Testing
- `npm test`
- `npm run build` (passes with existing webpack warning: `mode` option has not been set)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e56060fd-cf05-4130-bad0-3ac3f3b49805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e56060fd-cf05-4130-bad0-3ac3f3b49805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

