### PR TITLE
Add cookie-gated splash screen

### DIFF
--- a/app.js
+++ b/app.js
@@ -206,6 +206,10 @@ APP.use(function(req, res, next) {
   res.locals.realName = req.session.name;
   res.locals.token = req.session.token;
   res.locals.authenticated = req.isAuthenticated();
+  res.locals.showSplashScreen =
+    !req.get("HX-Request") &&
+    req.cookies?.siteSplashSeen !== "true" &&
+    req.cookies?.welcomeShown !== "true";
 
   res.locals.success = req.flash("success");
   res.locals.error = req.flash("error");

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -846,32 +846,65 @@ button.btn.btn-primary.right {
     }
 }
 
-.welcome {
+.site-splash {
     position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    font-size: 24px;
-    color: #333;
-    background-color: #fff;
-    padding: 20px;
-    border-radius: 10px;
-    box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
-    opacity: 1;
-    transition: opacity 1s ease-in-out;
-}
-
-.welcome.hide {
+    inset: 0;
+    z-index: 2000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem;
+    background: rgba(1, 52, 77, 0.92);
+    color: #ffffff;
     opacity: 0;
+    transition: opacity 0.4s ease;
 }
 
-#mainBody {
-    opacity: 0;
-    transition: opacity 1s ease-in-out;
+.site-splash[hidden] {
+    display: none;
 }
 
-#mainBody.fade-in {
+.site-splash--active {
     opacity: 1;
+}
+
+.site-splash--hiding {
+    opacity: 0;
+    pointer-events: none;
+}
+
+.site-splash__card {
+    width: min(90vw, 440px);
+    padding: 2.5rem;
+    text-align: center;
+    color: var(--color-text);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 16px;
+    box-shadow: var(--shadow-card);
+}
+
+.site-splash__card h1 {
+    margin-top: 0;
+}
+
+.site-splash__eyebrow {
+    margin-bottom: 0.75rem;
+    color: var(--color-text-muted);
+    font-size: 0.85rem;
+    font-weight: 700;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+}
+
+.site-splash__dismiss {
+    margin-top: 1rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .site-splash {
+        transition: none;
+    }
 }
 
 mark {

--- a/public/js/welcome.js
+++ b/public/js/welcome.js
@@ -1,29 +1,83 @@
-document.addEventListener("DOMContentLoaded", function() {
-  const welcomeMessage = document.getElementById("welcomeMsg");
-  const mainContent = document.getElementById("mainBody");
-  const hasVisited = document.cookie.includes("welcomeShown=true");
+(function() {
+  const SPLASH_COOKIE = "siteSplashSeen";
+  const LEGACY_SPLASH_COOKIE = "welcomeShown";
+  const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365 * 10;
+  const DISPLAY_DURATION_MS = 2500;
+  const TRANSITION_DURATION_MS = 400;
 
-  if (!hasVisited) {
-    // Show the welcome message
-    welcomeMessage.classList.remove("hide");
-    welcomeMessage.classList.add("show");
-
-    // Hold the welcome message for a few seconds, then fade it out
-    setTimeout(() => {
-      welcomeMessage.classList.add("hide"); // Start fade-out transition
-
-      // Delay before showing main content to allow the welcome message to fade out fully
-      setTimeout(() => {
-        welcomeMessage.classList.add("hidden"); // Hide the welcome message
-        mainContent.classList.remove("hidden"); // Make main content visible
-        mainContent.classList.add("fade-in"); // Apply fade-in effect to main content
-        document.body.style.overflow = "auto"; // Allow scrolling
-        document.cookie = "welcomeShown=true; max-age=31536000; path=/"; // Set the cookie
-      }, 1000); // Wait 1 second for fade-out to complete
-    }, 3000); // Show welcome message for 3 seconds before starting fade-out
-  } else {
-    mainContent.classList.remove("hidden"); // Show content immediately if visited before
-    mainContent.classList.add("fade-in"); // Fade in immediately if previously visited
-    document.body.style.overflow = "auto";
+  function getCookie(name) {
+    const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const match = document.cookie.match(new RegExp("(?:^|; )" + escapedName + "=([^;]*)"));
+    return match ? decodeURIComponent(match[1]) : null;
   }
-});
+
+  function setSplashSeenCookie() {
+    document.cookie =
+      SPLASH_COOKIE +
+      "=true; max-age=" +
+      COOKIE_MAX_AGE_SECONDS +
+      "; path=/; SameSite=Lax";
+  }
+
+  function hasSeenSplash() {
+    return getCookie(SPLASH_COOKIE) === "true" || getCookie(LEGACY_SPLASH_COOKIE) === "true";
+  }
+
+  function dismissSplash(splash) {
+    if (!splash || splash.dataset.dismissed === "true") {
+      return;
+    }
+
+    splash.dataset.dismissed = "true";
+    splash.classList.remove("site-splash--active");
+    splash.classList.add("site-splash--hiding");
+
+    window.setTimeout(function() {
+      splash.hidden = true;
+      splash.remove();
+    }, TRANSITION_DURATION_MS);
+  }
+
+  function showSplash() {
+    const splash = document.getElementById("siteSplash");
+
+    if (!splash) {
+      return;
+    }
+
+    if (hasSeenSplash()) {
+      splash.remove();
+      return;
+    }
+
+    setSplashSeenCookie();
+    splash.hidden = false;
+
+    window.requestAnimationFrame(function() {
+      splash.classList.add("site-splash--active");
+    });
+
+    const dismissButton = splash.querySelector("[data-splash-dismiss]");
+    if (dismissButton) {
+      dismissButton.addEventListener("click", function() {
+        dismissSplash(splash);
+      });
+    }
+
+    document.addEventListener("keydown", function(event) {
+      if (event.key === "Escape") {
+        dismissSplash(splash);
+      }
+    });
+
+    window.setTimeout(function() {
+      dismissSplash(splash);
+    }, DISPLAY_DURATION_MS);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", showSplash);
+  } else {
+    showSplash();
+  }
+})();

--- a/routes/login.js
+++ b/routes/login.js
@@ -8,6 +8,34 @@ import ValidTarget from "../utils/validTarget.js";
 
 const ROUTER = express.Router();
 
+function getSafeReturnTo(req) {
+  const rootURL = config.get("rootURL");
+  let returnTo = "/";
+
+  try {
+    if (typeof req.query.returnTo === "string" && req.query.returnTo !== "") {
+      returnTo = new URL(req.query.returnTo, rootURL).toString();
+    } else {
+      const currentURL = req.get("HX-Current-URL");
+
+      if (currentURL) {
+        const parsedCurrentURL = new URL(currentURL, rootURL);
+        const nestedReturnTo = parsedCurrentURL.searchParams.get("returnTo");
+
+        if (nestedReturnTo) {
+          returnTo = new URL(nestedReturnTo, rootURL).toString();
+        } else if (parsedCurrentURL.pathname !== "/login") {
+          returnTo = parsedCurrentURL.toString();
+        }
+      }
+    }
+  } catch (err) {
+    returnTo = "/";
+  }
+
+  return ValidTarget(returnTo) ? returnTo : "/";
+}
+
 ROUTER.get("/", [auth.ValidateLoggedOut], async (req, res) => {
   return res.render("login", {
     title: strings.pageHeader.login,
@@ -19,37 +47,15 @@ ROUTER.post(
   "/",
   [passport.authenticate("local", { failWithError: true })],
   function(req, res) {
-    var returnTo = "";
+    const returnTo = getSafeReturnTo(req);
     req.flash("success", strings.success.loginSuccess);
 
-    const HXReturnTo = req.get("HX-Current-URL");
-
-    if (HXReturnTo.includes("returnTo=")) {
-      var parts = HXReturnTo.split("returnTo=");
-      var returnParts = parts[1];
-      returnParts = decodeURIComponent(returnParts);
-      returnToPath = new URL(returnParts, config.get("rootURL"));
-      returnTo = returnToPath.toString();
-    } else {
-      returnTo = "/";
+    if (req.get("HX-Request")) {
+      res.set("HX-Redirect", returnTo);
+      return res.status(200).end();
     }
 
-    if (req.query.returnTo !== undefined) {
-      var returnToPath = new URL(req.query.returnTo, config.get("rootURL"));
-      returnTo = returnToPath.toString();
-    }
-
-    if (returnTo !== undefined && returnTo !== "") {
-      if (!ValidTarget(returnTo)) {
-        returnTo = "/";
-      }
-    } else {
-      returnTo = "/";
-    }
-
-    res.set("HX-Redirect", returnTo);
-    res.send('<meta http-equiv="refresh" content="0');
-    res.status(200).end();
+    return res.redirect(returnTo);
   },
   function(err, req, res, next) {
     // console.log(err);
@@ -71,22 +77,15 @@ ROUTER.post(
   "/modal",
   passport.authenticate("local", { failWithError: true }),
   function(req, res) {
-    var returnTo = "";
+    const returnTo = getSafeReturnTo(req);
     req.flash("success", strings.success.loginSuccess);
 
-    const HXReturnTo = req.get("HX-Current-URL");
-
-    if (HXReturnTo !== undefined) {
-      var returnTo = HXReturnTo;
-      if (!ValidTarget(HXReturnTo)) {
-        returnTo = "/";
-      }
-    } else {
-      returnTo = "/";
+    if (req.get("HX-Request")) {
+      res.set("HX-Redirect", returnTo);
+      return res.status(200).end();
     }
 
-    res.set("HX-Location", returnTo);
-    res.status(200).end();
+    return res.redirect(returnTo);
   },
   function(err, req, res, next) {
     res.send(

--- a/views/layouts/admin.handlebars
+++ b/views/layouts/admin.handlebars
@@ -4,6 +4,7 @@
 {{> header}}
 <body>
     {{> theme-script}}
+    {{> splash-screen}}
     {{> nav}}
     {{> login}}
     <div id="statusBox" hx-target="this" hx-swap="innerHTML" hx-trigger="load">{{> status}}</div>
@@ -22,6 +23,7 @@
     <script src="https://unpkg.com/htmx.org/dist/ext/response-targets.js" nonce="{{nonce}}"></script>
     <script rel="text/javascript" src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" nonce="{{nonce}}"></script>
     <script rel="text/javascript" src="{{ versionedFile 'site.js' 'dist' 'js'}}" nonce="{{nonce}}"></script>
+    <script rel="text/javascript" src="{{ versionedFile 'welcome.js' 'dist' 'js'}}" nonce="{{nonce}}"></script>
     <script rel="text/javascript" src="{{ versionedFile 'admin.js' 'dist' 'js'}}" nonce="{{nonce}}"></script>
     <script
         src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -4,16 +4,14 @@
 {{> header}}
 <body>
     {{> theme-script}}
-    <!--<div id="welcomeMsg" class="welcome hide">Hey, I'm Ryan, and welcome to my site!</div>-->
-    <!--<div id="mainBody"> -->
-        {{> nav}}
-        <div id="statusBox" hx-target="this" hx-swap="innerHTML" hx-trigger="load" nonce="{{nonce}}">{{> status}}</div>
-        {{> login}}
-        {{{ body }}}
+    {{> splash-screen}}
+    {{> nav}}
+    <div id="statusBox" hx-target="this" hx-swap="innerHTML" hx-trigger="load" nonce="{{nonce}}">{{> status}}</div>
+    {{> login}}
+    {{{ body }}}
 
-        {{!-- In the footer we display the currentyear variable that we set in the app.js file --}}
-        {{> footer currentyear=currentyear}}
-    <!-- </div> --> 
+    {{!-- In the footer we display the currentyear variable that we set in the app.js file --}}
+    {{> footer currentyear=currentyear}}
     <script nonce="{{nonce}}">
         if (!window.grecaptcha) {
             const script = document.createElement('script');
@@ -33,7 +31,7 @@
     <script nonce="{{nonce}}">hljs.highlightAll();</script>
     <!--<script rel="text/javascript" src="{{ versionedFile 'trustedtype.js' 'dist' 'js'}}" nonce="{{nonce}}"></script>-->
     <script type="module" src="{{ versionedFile 'trustedtype.js' 'dist' 'js'}}" nonce="{{nonce}}"></script>
-    {{!-- <script rel="text/javascript" src="{{ versionedFile 'welcome.js' 'dist' 'js'}}" nonce="{{nonce}}"></script> --}}
+    <script rel="text/javascript" src="{{ versionedFile 'welcome.js' 'dist' 'js'}}" nonce="{{nonce}}"></script>
     {{!-- <script type="text/javascript" nonce="{{nonce}}" src="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"></script> --}}
     {{!-- <script src="https://www.google.com/recaptcha/api.js?render=6LeCKqYUAAAAAAh4n_WgK7e-fKbqOgrukjjBmqBG" nonce="{{nonce}}" async defer></script> --}}
 </body>

--- a/views/layouts/new-project.handlebars
+++ b/views/layouts/new-project.handlebars
@@ -4,6 +4,7 @@
 {{> header}}
 <body>
     {{> theme-script}}
+    {{> splash-screen}}
     {{> nav}}
     <div id="statusBox" hx-target="this" hx-swap="innerHTML" hx-trigger="load">{{> status}}</div>
     {{> confirmation}}
@@ -26,6 +27,7 @@
     </script>
     <script rel="text/javascript" nonce="{{nonce}}" src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js"></script>
     <script nonce="{{nonce}}" src="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js"></script>
+    <script rel="text/javascript" src="{{ versionedFile 'welcome.js' 'dist' 'js'}}" nonce="{{nonce}}"></script>
     <script rel="text/javascript" src="{{ versionedFile 'new-project.js' 'dist' 'js'}}" nonce="{{nonce}}"></script>
     <script nonce="{{nonce}}">
         var simplemde = new SimpleMDE({ element: document.getElementById("project_description"), toolbar: ["preview"], placeholder: "Project Description Here - Write in Markdown", });

--- a/views/layouts/news.handlebars
+++ b/views/layouts/news.handlebars
@@ -4,6 +4,7 @@
 {{> header}}
 <body>
     {{> theme-script}}
+    {{> splash-screen}}
     {{> nav}}
     <div id="statusBox" hx-target="this" hx-swap="innerHTML" hx-trigger="load" nonce="{{nonce}}">{{> status}}</div>
     {{{ body }}}
@@ -21,6 +22,7 @@
     <script rel="text/javascript" src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" nonce="{{nonce}}"></script>
     
     <script rel="text/javascript" src="{{ versionedFile 'site.js' 'dist' 'js'}}" nonce="{{nonce}}"></script>
+    <script rel="text/javascript" src="{{ versionedFile 'welcome.js' 'dist' 'js'}}" nonce="{{nonce}}"></script>
     <script
         src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"
         integrity="sha256-VazP97ZCwtekAsvgPBSUwPFKdrwD3unUfSGVYrahUqU="

--- a/views/layouts/newsIndex.handlebars
+++ b/views/layouts/newsIndex.handlebars
@@ -4,6 +4,7 @@
 {{> header}}
 <body>
     {{> theme-script}}
+    {{> splash-screen}}
     {{> nav}}
     <div id="statusBox" hx-target="this" hx-swap="innerHTML" hx-trigger="load">{{> status}}</div>
     {{> login}}
@@ -21,6 +22,7 @@
     <script rel="text/javascript" src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" nonce="{{nonce}}"></script>
     <script rel="text/javascript" src="/js/jquery.simplePagination.js" nonce="{{nonce}}"></script>
     <script rel="text/javascript" src="{{ versionedFile 'site.js' 'dist' 'js'}}" nonce="{{nonce}}"></script>
+    <script rel="text/javascript" src="{{ versionedFile 'welcome.js' 'dist' 'js'}}" nonce="{{nonce}}"></script>
     <script rel="text/javascript" src="{{ versionedFile 'news.js' 'dist' 'js'}}" nonce="{{nonce}}"></script>
     <script
         src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"

--- a/views/layouts/profile.handlebars
+++ b/views/layouts/profile.handlebars
@@ -4,6 +4,7 @@
 {{> header}}
 <body>
     {{> theme-script}}
+    {{> splash-screen}}
     {{> nav}}
     <div id="statusBox" hx-target="this" hx-swap="innerHTML" hx-trigger="load">{{> status}}</div>
     {{> login}}
@@ -18,6 +19,7 @@
     </script>
     <script rel="text/javascript" src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" nonce="{{nonce}}"></script>
     <script rel="text/javascript" src="{{ versionedFile 'site.js' 'dist' 'js'}}" nonce="{{nonce}}"></script>
+    <script rel="text/javascript" src="{{ versionedFile 'welcome.js' 'dist' 'js'}}" nonce="{{nonce}}"></script>
     <script rel="text/javascript" src="{{ versionedFile 'profile.js' 'dist' 'js'}}" nonce="{{nonce}}"></script>
     <script
         src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"

--- a/views/layouts/reset.handlebars
+++ b/views/layouts/reset.handlebars
@@ -4,6 +4,7 @@
 {{> header}}
 <body>
     {{> theme-script}}
+    {{> splash-screen}}
     {{> nav-no-login}}
     <div id="statusBox" hx-target="this" hx-swap="innerHTML" hx-trigger="load">{{> status}}</div>
     {{{ body }}}
@@ -16,6 +17,7 @@
         crossorigin="anonymous" nonce="{{nonce}}">
     </script>
     <script rel="text/javascript" src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" nonce="{{nonce}}"></script>
+    <script rel="text/javascript" src="{{ versionedFile 'welcome.js' 'dist' 'js'}}" nonce="{{nonce}}"></script>
     <script
         src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"
         integrity="sha256-VazP97ZCwtekAsvgPBSUwPFKdrwD3unUfSGVYrahUqU="

--- a/views/layouts/update-project.handlebars
+++ b/views/layouts/update-project.handlebars
@@ -4,6 +4,7 @@
 {{> header}}
 <body>
     {{> theme-script}}
+    {{> splash-screen}}
     {{> nav}}
     <div id="statusBox" hx-target="this" hx-swap="innerHTML" hx-trigger="load">{{> status}}</div>
     {{> confirmation}}
@@ -26,6 +27,7 @@
     </script>
     <script rel="text/javascript" nonce="{{nonce}}" src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js"></script>
     <script nonce="{{nonce}}" src="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js"></script>
+    <script rel="text/javascript" src="{{ versionedFile 'welcome.js' 'dist' 'js'}}" nonce="{{nonce}}"></script>
     <script rel="text/javascript" src="{{ versionedFile 'update-project.js' 'dist' 'js'}}" nonce="{{nonce}}"></script>
     <script nonce="{{nonce}}">
         var simplemde = new SimpleMDE({ element: document.getElementById("project_description"), toolbar: ["preview"], placeholder: "Project Description Here - Write in Markdown", });

--- a/views/partials/splash-screen.handlebars
+++ b/views/partials/splash-screen.handlebars
@@ -1,0 +1,12 @@
+{{#if showSplashScreen}}
+<div id="siteSplash" class="site-splash" role="dialog" aria-modal="true" aria-labelledby="siteSplashTitle" hidden>
+    <div class="site-splash__card">
+        <p class="site-splash__eyebrow">Welcome</p>
+        <h1 id="siteSplashTitle">Ryan Malacina</h1>
+        <p>Hey there, I'm Ryan, and welcome to my site!</p>
+        <button type="button" class="btn btn-primary site-splash__dismiss" data-splash-dismiss>
+            Continue
+        </button>
+    </div>
+</div>
+{{/if}}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a shared splash screen overlay gated by a long-lived `siteSplashSeen` cookie
- Keep page content in the normal render path so the splash cannot leave the app hidden after login
- Use full-page HTMX redirects for login success flows and safely resolve `returnTo` targets

## Testing
- `npm test` (6 suites, 17 tests passed)
- `npm run build` (passed; existing webpack mode warning remains)

## Notes
- The new splash check also honors the previous `welcomeShown=true` cookie so anyone with the older marker will not see the splash again.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-473892c3-bbf5-406f-b408-470a1db99d48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-473892c3-bbf5-406f-b408-470a1db99d48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

